### PR TITLE
Education now uses `<time>`

### DIFF
--- a/src/layout/Education.jsx
+++ b/src/layout/Education.jsx
@@ -25,7 +25,8 @@ const Education = () => {
           <div className="col-md-6 col-sm-6 text-sm-end">
             <p className="h6">
               <Emoji>🗓️</Emoji>
-              Aug '19 - May '23
+              <time datetime="2019-08">Aug '19</time> -{" "}
+              <time dateTime="2023-05">May '23</time>
             </p>
           </div>
           <div className="row">


### PR DESCRIPTION
As refactoring `Work` to use `<time>` elements will take some more consideration, `Edcuation` will receive the `<time>` refactor first. 

Given that dates on this site will rarely change, hardcoding them for now is fine. If we were making a component where we couldn't assume a date, then we would code up a way to convert a time to use in a `<time>` element